### PR TITLE
Update everything to conform the 0.3.0 DBus spec

### DIFF
--- a/_examples/basic_c_example/main.c
+++ b/_examples/basic_c_example/main.c
@@ -94,7 +94,7 @@ void pickDistributors()
 int main(int argc, char **argv)
 {
 
-	bool ok = UPInitializeAndCheck("cc.malhotra.karmanyaah.testapp.cgo", *newMessage, *newEndpoint, *unregistered);
+	bool ok = UPInitializeAndCheck("cc.malhotra.karmanyaah.testapp.cgo", "C example app", *newMessage, *newEndpoint, *unregistered);
 	if (ok) printf("successfully initialized notifications\n");
 
 	if (strnlen(UPGetDistributor(), 1) == 0)

--- a/_examples/basic_example/main.go
+++ b/_examples/basic_example/main.go
@@ -13,10 +13,10 @@ var Endpoint string
 
 type NotificationHandler struct{}
 
-func (n NotificationHandler) Message(instance, message, id string) {
+func (n NotificationHandler) Message(instance string, message []byte, id string) {
 	fmt.Println("new message received")
 	// this message can be in whatever format you like, in this case the title and message body are two strings seperated by a '-'
-	parts := strings.Split(message, "-")
+	parts := strings.Split(string(message), "-")
 
 	title := "No Title Provided"
 	if len(parts) > 1 {

--- a/_examples/basic_example/main.go
+++ b/_examples/basic_example/main.go
@@ -42,7 +42,7 @@ func (n NotificationHandler) Unregistered(instance string) {
 
 func main() {
 	connector := NotificationHandler{}
-	up.InitializeAndCheck("cc.malhotra.karmanyaah.testapp.golibrary", connector)
+	up.InitializeAndCheck("cc.malhotra.karmanyaah.testapp.golibrary", "Golang Example App", connector)
 
 	if len(up.GetDistributor()) == 0 { // not picked distributor yet
 		pickDist()

--- a/api/api.go
+++ b/api/api.go
@@ -125,6 +125,13 @@ func InitializeAndCheck(fullName, friendlyName string, handler dbus.ConnectorHan
 // value of instance can be empty string for the default instance
 // registration endpoint is returned through the callback if method is successful
 func Register(instance string) (registerStatus definitions.RegisterStatus, registrationFailReason string, err error) {
+	return RegisterWithDescription(instance, "")
+}
+
+// RegisterWithDescription registers a new instance with a specific description.
+// value of instance can be empty string for the default instance
+// registration endpoint is returned through the callback if method is successful
+func RegisterWithDescription(instance, description string) (registerStatus definitions.RegisterStatus, registrationFailReason string, err error) {
 	if len(GetDistributor()) == 0 {
 		err = errors.New("No distributor selected")
 		return
@@ -132,7 +139,7 @@ func Register(instance string) (registerStatus definitions.RegisterStatus, regis
 
 	in, ok := getToken(instance)
 	if !ok {
-		in, err = generateNewToken(instance, "")
+		in, err = generateNewToken(instance, description)
 		if err != nil {
 			return
 		}

--- a/api/api.go
+++ b/api/api.go
@@ -25,7 +25,7 @@ type connector struct {
 	t chan time.Time
 }
 
-func (ch connector) Message(token, msg, id string) {
+func (ch connector) Message(token string, msg []byte, id string) {
 	if ch.t != nil {
 		ch.t <- time.Now()
 	}

--- a/api/api.go
+++ b/api/api.go
@@ -15,6 +15,7 @@ import (
 var ErrInstanceNotUnregistered = errors.New("Instance isn't unregistered yet")
 
 var client *dbus.Client
+var friendlyAppName string
 
 // maybe mutex the globals?
 var dataStore *store.Storage
@@ -52,15 +53,15 @@ func (ch connector) Unregistered(token string) {
 	ch.c.Unregistered(instance)
 }
 
-// Initializes the bus and object
-func Initialize(name string, handler dbus.ConnectorHandler) error {
-	if len(name) == 0 {
+// Initialize the bus and object
+func Initialize(fullName, friendlyName string, handler dbus.ConnectorHandler) error {
+	if len(fullName) == 0 {
 		return errors.New("invalid name")
 	}
 	if client != nil {
 		client.Close()
 	}
-	client = dbus.NewClient(name)
+	client = dbus.NewClient(fullName)
 	err := client.InitializeDefaultConnection()
 	if err != nil {
 		return errors.New("DBus Error")
@@ -77,10 +78,12 @@ func Initialize(name string, handler dbus.ConnectorHandler) error {
 	if err != nil {
 		return errors.New("DBus Error")
 	}
-	dataStore = store.NewStorage(name)
+	dataStore = store.NewStorage(fullName)
 	if dataStore == nil {
 		return errors.New("Storage Err")
 	}
+
+	friendlyAppName = friendlyName
 	return nil
 }
 
@@ -88,13 +91,13 @@ func Initialize(name string, handler dbus.ConnectorHandler) error {
 // The background check checks whether the argument UNIFIEDPUSH_DBUS_BACKGROUND_ACTIVATION is input.
 // Listens for 3 seconds after the last message and then exits.
 // if running in the background this panics on error
-func InitializeAndCheck(name string, handler dbus.ConnectorHandler) error {
+func InitializeAndCheck(fullName, friendlyName string, handler dbus.ConnectorHandler) error {
 	if !containsString(os.Args, definitions.ConnectorBackgroundArgument) {
-		return Initialize(name, handler)
+		return Initialize(fullName, friendlyName, handler)
 	}
 	lastCallTime := make(chan time.Time)
 
-	err := Initialize(name, connector{c: handler, t: lastCallTime})
+	err := Initialize(fullName, friendlyName, connector{c: handler, t: lastCallTime})
 	if err != nil {
 		panic(err)
 		// panic bc in bg listener
@@ -118,7 +121,7 @@ func InitializeAndCheck(name string, handler dbus.ConnectorHandler) error {
 
 // Actual UP methods
 
-// TryRegister registers a new instance.
+// Register registers a new instance.
 // value of instance can be empty string for the default instance
 // registration endpoint is returned through the callback if method is successful
 func Register(instance string) (registerStatus definitions.RegisterStatus, registrationFailReason string, err error) {
@@ -127,13 +130,14 @@ func Register(instance string) (registerStatus definitions.RegisterStatus, regis
 		return
 	}
 
-	if len(getToken(instance)) == 0 {
-		err = saveNewToken(instance)
+	in, ok := getToken(instance)
+	if !ok {
+		in, err = generateNewToken(instance, "")
 		if err != nil {
 			return
 		}
 	}
-	status, reason := client.PickDistributor(GetDistributor()).Register(dataStore.AppName, getToken(instance))
+	status, reason := client.PickDistributor(GetDistributor()).Register(dataStore.AppName, in.Token, in.Description)
 	if status == definitions.RegisterStatusFailed || status == definitions.RegisterStatusRefused {
 		err = removeToken(instance)
 	}
@@ -143,7 +147,11 @@ func Register(instance string) (registerStatus definitions.RegisterStatus, regis
 // TryUnregister attempts unregister, results are returned through callback
 // any error returned is before unregister requested from dbus
 func TryUnregister(instance string) error {
-	return client.PickDistributor(GetDistributor()).Unregister(getToken(instance))
+	in, ok := getToken(instance)
+	if !ok {
+		return errors.New("Instance not found")
+	}
+	return client.PickDistributor(GetDistributor()).Unregister(in.Token)
 }
 
 // Distributor things
@@ -191,21 +199,31 @@ func RemoveDistributor() error {
 // Token things
 
 // getToken returns token for instance or empty string if instance doesn't exist
-func getToken(instance string) string {
+func getToken(instance string) (store.Instance, bool) {
 	a, ok := dataStore.Instances[instance]
 	if !ok {
-		return ""
+		return store.Instance{}, false
 	}
-	return a.Token
+	return a, true
 }
 
-func saveNewToken(instance string) error {
+func generateNewToken(instance, description string) (store.Instance, error) {
 	token, err := uuid.NewRandom()
 	if err != nil {
-		return err
+		return store.Instance{}, err
 	}
-	dataStore.Instances[instance] = store.Instance{Token: token.String()}
-	return dataStore.Commit()
+
+	// generate description if none is given
+	if len(description) == 0 {
+		description = friendlyAppName + " - " + instance
+		// just use the friendly name if there is only 1 instance
+		if len(instance) == 0 {
+			description = friendlyAppName
+		}
+	}
+
+	dataStore.Instances[instance] = store.Instance{Token: token.String(), Description: description}
+	return dataStore.Instances[instance], dataStore.Commit()
 }
 
 func removeToken(instance string) error {

--- a/api_c/api.go
+++ b/api_c/api.go
@@ -156,7 +156,12 @@ func UPGetDistributor() *C.char {
 
 //export UPRegister
 func UPRegister(instance *C.char) (status C.UP_REGISTER_STATUS, reason *C.char) {
-	statusret, reasonret, errret := api.Register(C.GoString(instance))
+	return UPRegisterWithDescription(instance, C.CString(""))
+}
+
+//export UPRegisterWithDescription
+func UPRegisterWithDescription(instance *C.char, description *C.char) (status C.UP_REGISTER_STATUS, reason *C.char) {
+	statusret, reasonret, errret := api.RegisterWithDescription(C.GoString(instance), C.GoString(description))
 	status = (C.UP_REGISTER_STATUS)(statusret)
 	reason = C.CString(reasonret)
 	if errret != nil {

--- a/api_c/api.go
+++ b/api_c/api.go
@@ -66,7 +66,8 @@ func (c Connector) Unregistered(a string) {
  */
 //export UPInitializeAndCheck
 func UPInitializeAndCheck(
-	name *C.char,
+	fullName *C.char,
+	friendlyName *C.char,
 	msg *C.messageCallback,
 	endpoint *C.endpointCallback,
 	unregistered *C.unregisteredCallback,
@@ -76,7 +77,7 @@ func UPInitializeAndCheck(
 		newEndpoint:  endpoint,
 		unregistered: unregistered,
 	}
-	err := api.InitializeAndCheck(C.GoString(name), connector)
+	err := api.InitializeAndCheck(C.GoString(fullName), C.GoString(friendlyName), connector)
 	return err == nil
 }
 
@@ -85,7 +86,8 @@ func UPInitializeAndCheck(
  */
 //export UPInitialize
 func UPInitialize(
-	name *C.char,
+	fullName *C.char,
+	friendlyName *C.char,
 	msg *C.messageCallback,
 	endpoint *C.endpointCallback,
 	unregistered *C.unregisteredCallback,
@@ -95,7 +97,7 @@ func UPInitialize(
 		newEndpoint:  endpoint,
 		unregistered: unregistered,
 	}
-	err := api.Initialize(C.GoString(name), connector)
+	err := api.Initialize(C.GoString(fullName), C.GoString(friendlyName), connector)
 	return err == nil
 }
 

--- a/dbus/distributor.go
+++ b/dbus/distributor.go
@@ -15,9 +15,9 @@ type Distributor struct {
 	object dbus.BusObject
 }
 
-func (d *Distributor) Register(name, token string) (definitions.RegisterStatus, string) {
+func (d *Distributor) Register(name, token, description string) (definitions.RegisterStatus, string) {
 	var status, reason string
-	err := d.object.Call(definitions.DistributorInterface+".Register", dbus.Flags(0), name, token).Store(&status, &reason)
+	err := d.object.Call(definitions.DistributorInterface+".Register", dbus.Flags(0), name, token, description).Store(&status, &reason)
 	if err != nil {
 		return definitions.RegisterStatusFailedRequest, ""
 	}

--- a/dbus/init.go
+++ b/dbus/init.go
@@ -81,7 +81,7 @@ func NewConnector(handler ConnectorHandler) Connector {
 }
 
 type ConnectorHandler interface {
-	Message(token, message, msgID string)
+	Message(token string, message []byte, msgID string)
 	NewEndpoint(token, endpoint string)
 	Unregistered(token string)
 }
@@ -90,7 +90,7 @@ type Connector struct {
 	h ConnectorHandler
 }
 
-func (c Connector) Message(token, message, msgID string) *dbus.Error {
+func (c Connector) Message(token string, message []byte, msgID string) *dbus.Error {
 	c.h.Message(token, message, msgID)
 	return nil
 }

--- a/definitions/dbus.go
+++ b/definitions/dbus.go
@@ -61,7 +61,7 @@ const (
 )
 
 var RegisterStatusMap = map[string]RegisterStatus{
-	"NEW_ENDPOINT":         RegisterStatusNewEndpoint,
-	"REGISTRATION_REFUSED": RegisterStatusRefused,
-	"REGISTRATION_FAILED":  RegisterStatusFailed,
+	"REGISTRATION_SUCCEEDED": RegisterStatusNewEndpoint,
+	"REGISTRATION_REFUSED":   RegisterStatusRefused,
+	"REGISTRATION_FAILED":    RegisterStatusFailed,
 }

--- a/store/store.go
+++ b/store/store.go
@@ -9,7 +9,8 @@ import (
 )
 
 type Instance struct {
-	Token string
+	Token       string
+	Description string
 }
 
 func NewStorage(appName string) *Storage {


### PR DESCRIPTION
## Description
This merge request fixes the dbus API to be in line with the spec (this package was never updated from 0.2.0 to 0.3.0).  
This comprises of the registration (distributor) and message (connector) signature. This is/was a breaking change.


## Noteworthy changes
### General
This merge request changes the initialization from just the long app name (reverse FQDN format) and a callback class to include a friendly application name as second parameter (moving the callback class to the third)

This friendly name is used when registering in combination with the instance given by the app to generate a nice description for the notification session. (Allowing distributors to display a user friendly list of registrations.)

A second registration function is added to allow overriding the description by the application itself

### Internal changes
The description field is added to the 'instance' object in the store.

The generation and retrieval of tokens / 'instance' objects is changed to return the 'instance' so the description is also available when registering.

Internally the description is currently only set the first time an 'instance' / token is generated. During registration the description is simply taken from the 'instance' object.

`saveNewToken()` is renamed to `generateNewToken()` to convey the generation and not just storing of a token


## Progress
- [x] Registration changes
  - [x] Update internal dbus call and required changes (description field)
  - [x] Update registration return checking (return status string change)
  - [x] Update C api
  - [x] Update golang example
  - [x] Update C example
  - [x] Add function to register with an explicitly given description
- [x] Message changes
  - [x] Update golang API
  - [x] Update C api
  - [x] Update golang example
  - [x] Update C example

Fixes #8